### PR TITLE
fix padding,group,format null issue

### DIFF
--- a/patches/nginx.patch
+++ b/patches/nginx.patch
@@ -1,5 +1,5 @@
 diff --git a/src/event/ngx_event_openssl.c b/src/event/ngx_event_openssl.c
-index 7b0417e4..ff16cfc8 100644
+index 91b415ca..fbce04af 100644
 --- a/src/event/ngx_event_openssl.c
 +++ b/src/event/ngx_event_openssl.c
 @@ -8,6 +8,7 @@
@@ -10,7 +10,7 @@ index 7b0417e4..ff16cfc8 100644
  
  
  #define NGX_SSL_PASSWORD_BUFFER_SIZE  4096
-@@ -1710,6 +1711,166 @@ ngx_ssl_set_session(ngx_connection_t *c, ngx_ssl_session_t *session)
+@@ -1588,6 +1589,176 @@ ngx_ssl_set_session(ngx_connection_t *c, ngx_ssl_session_t *session)
      return NGX_OK;
  }
  
@@ -147,8 +147,13 @@ index 7b0417e4..ff16cfc8 100644
 +            *ptr++ = '-';
 +        }
 +    }
-+    *(ptr-1) = ',';
-+    data += num;
++
++    if (num != 0) {
++        *(ptr-1) = ',';
++        data += num;
++    } else {
++        *(ptr) = ',';
++    }
 +
 +    /* formats */
 +    num = *(uint8_t*)data;
@@ -156,8 +161,13 @@ index 7b0417e4..ff16cfc8 100644
 +        ptr = append_uint16(ptr, (uint16_t)data[i]);
 +        *ptr++ = '-';
 +    }
-+    *(ptr-1) = ',';
-+    data += num;
++
++    if (num != 0) {
++        *(ptr-1) = ',';
++        data += num;
++    } else {
++        *(ptr) = ',';
++    }
 +
 +    /* end */
 +    *ptr-- = 0;
@@ -177,7 +187,7 @@ index 7b0417e4..ff16cfc8 100644
  
  ngx_int_t
  ngx_ssl_handshake(ngx_connection_t *c)
-@@ -1730,12 +1891,18 @@ ngx_ssl_handshake(ngx_connection_t *c)
+@@ -1603,12 +1774,18 @@ ngx_ssl_handshake(ngx_connection_t *c)
  
      ngx_ssl_clear_error(c->log);
  
@@ -198,11 +208,11 @@ index 7b0417e4..ff16cfc8 100644
              return NGX_ERROR;
          }
 diff --git a/src/event/ngx_event_openssl.h b/src/event/ngx_event_openssl.h
-index c9e86d9c..d037b956 100644
+index 61da0c5d..1c6d99f4 100644
 --- a/src/event/ngx_event_openssl.h
 +++ b/src/event/ngx_event_openssl.h
-@@ -119,6 +119,11 @@ struct ngx_ssl_connection_s {
-     unsigned                    in_ocsp:1;
+@@ -99,6 +99,11 @@ struct ngx_ssl_connection_s {
+     unsigned                    in_early:1;
      unsigned                    early_preread:1;
      unsigned                    write_blocked:1;
 +

--- a/patches/openssl.1_1_1.patch
+++ b/patches/openssl.1_1_1.patch
@@ -1,5 +1,5 @@
 diff --git a/include/openssl/ssl.h b/include/openssl/ssl.h
-index b744f6ccc1..b956e851ab 100644
+index 9af0c8995e..c77a04cd90 100644
 --- a/include/openssl/ssl.h
 +++ b/include/openssl/ssl.h
 @@ -1818,6 +1818,7 @@ size_t SSL_client_hello_get0_ciphers(SSL *s, const unsigned char **out);
@@ -31,10 +31,10 @@ index 76d9fda46e..a29114f215 100644
  # define TLSEXT_TYPE_session_ticket              35
  
 diff --git a/ssl/ssl_lib.c b/ssl/ssl_lib.c
-index 25a1a44785..57d26e860e 100644
+index 25a1a44785..bceb43308f 100644
 --- a/ssl/ssl_lib.c
 +++ b/ssl/ssl_lib.c
-@@ -5205,6 +5205,95 @@ int SSL_client_hello_get1_extensions_present(SSL *s, int **out, size_t *outlen)
+@@ -5205,6 +5205,98 @@ int SSL_client_hello_get1_extensions_present(SSL *s, int **out, size_t *outlen)
      return 0;
  }
  
@@ -94,6 +94,9 @@ index 25a1a44785..57d26e860e 100644
 +        if (ext->present) {
 +            if (ext->received_order >= num)
 +                break;
++	    // Ingore padding due to padding is null where reuse the session_ticket.
++            if (ext->type== TLSEXT_TYPE_padding)
++                continue;
 +            if (ext->type== TLSEXT_TYPE_supported_groups)
 +                groups = &ext->data;
 +            if (ext->type== TLSEXT_TYPE_ec_point_formats)
@@ -131,7 +134,7 @@ index 25a1a44785..57d26e860e 100644
                         size_t *outlen)
  {
 diff --git a/ssl/ssl_local.h b/ssl/ssl_local.h
-index 4c36cd5c89..ac0ec97b65 100644
+index 5c79215423..a3038c79ea 100644
 --- a/ssl/ssl_local.h
 +++ b/ssl/ssl_local.h
 @@ -714,6 +714,10 @@ typedef enum tlsext_index_en {


### PR DESCRIPTION
change:
1. left comma if `group` or `format` is null,  keep ja3 has 5 fields.
2. ignore padding extension due to padding will null when resuing session ticket 