### PR TITLE
http2_fingerprint fixe and other improvements & fixes

### DIFF
--- a/config
+++ b/config
@@ -1,3 +1,8 @@
+
+#
+# JA3 module conf
+#
+
 ngx_addon_name=ngx_ssl_fingerprint_module
 
 CORE_LIBS="$CORE_LIBS"
@@ -8,9 +13,13 @@ STREAM_MODULES="ngx_stream_ssl_fingerprint_preread_module $STREAM_MODULES"
 
 HTTP_MODULES="$HTTP_MODULES ngx_http_ssl_fingerprint_module"
 
-NGX_ADDON_SRCS="$NGX_ADDON_SRCS                         \
+NGX_ADDON_SRCS="$NGX_ADDON_SRCS \
  $ngx_addon_dir/src/nginx_ssl_fingerprint.c \
  $ngx_addon_dir/src/ngx_stream_ssl_fingerprint_preread_module.c \
  $ngx_addon_dir/src/ngx_http_ssl_fingerprint_module.c
  "
+
+CFLAGS="$CFLAGS -I$ngx_addon_dir"
+
+have=NGX_JA3_FINGERPRING_MODULE  . auto/have
 

--- a/patches/nginx-1.27.patch
+++ b/patches/nginx-1.27.patch
@@ -1,0 +1,180 @@
+diff --git a/src/event/ngx_event_openssl.c b/src/event/ngx_event_openssl.c
+index 2f68a55de..d069b72ea 100644
+--- a/src/event/ngx_event_openssl.c
++++ b/src/event/ngx_event_openssl.c
+@@ -11,6 +11,7 @@
+ #include <ngx_event.h>
+ 
+ 
++#define NGX_SSL_JA3_BUFFER_SIZE 256 /* = (sizeof(uint16_t) * 128) */
+ #define NGX_SSL_PASSWORD_BUFFER_SIZE  4096
+ 
+ #if (NGX_HAVE_NTLS)
+@@ -1971,6 +1972,40 @@ ngx_ssl_set_session(ngx_connection_t *c, ngx_ssl_session_t *session)
+     return NGX_OK;
+ }
+ 
++int
++ngx_ssl_client_hello_ja3_cb(SSL *s, int *al, void *arg)
++{
++    ngx_connection_t  *c = arg;
++    ngx_str_t         *ja;
++
++    if (c == NULL) {
++        return SSL_CLIENT_HELLO_SUCCESS;
++    }
++
++    if (c->ssl == NULL) {
++        return SSL_CLIENT_HELLO_SUCCESS;
++    }
++
++    ja = &c->ssl->fp_ja3_data;
++    ja->len = NGX_SSL_JA3_BUFFER_SIZE;
++
++    ja->data = ngx_pnalloc(c->pool, c->ssl->fp_ja3_data.len);
++    if (ja->data == NULL) {
++        ja->len = 0;
++        return SSL_CLIENT_HELLO_SUCCESS;
++    }
++
++    ja->len = SSL_client_hello_get_ja3_data(c->ssl->connection, ja->data,
++            NGX_SSL_JA3_BUFFER_SIZE);
++    if (ja->len == 0) {
++        ngx_log_error(NGX_LOG_WARN, c->log, 0, "SSL_client_hello_get_ja3_data "
++                "seems the buffer size is less that number of fileds; "
++                "for this SSL connection can't get a ja3 hash string");
++        ja->data = NULL;
++    }
++
++    return SSL_CLIENT_HELLO_SUCCESS;
++}
+ 
+ ngx_int_t
+ ngx_ssl_handshake(ngx_connection_t *c)
+@@ -1991,6 +2026,9 @@ ngx_ssl_handshake(ngx_connection_t *c)
+ 
+     ngx_ssl_clear_error(c->log);
+ 
++    (void) SSL_CTX_set_client_hello_cb(c->ssl->session_ctx,
++                                ngx_ssl_client_hello_ja3_cb, c);
++
+     n = SSL_do_handshake(c->ssl->connection);
+ 
+     ngx_log_debug1(NGX_LOG_DEBUG_EVENT, c->log, 0, "SSL_do_handshake: %d", n);
+diff --git a/src/event/ngx_event_openssl.h b/src/event/ngx_event_openssl.h
+index 42a01ce62..c4adc270d 100644
+--- a/src/event/ngx_event_openssl.h
++++ b/src/event/ngx_event_openssl.h
+@@ -129,6 +129,11 @@ struct ngx_ssl_connection_s {
+     unsigned                    in_ocsp:1;
+     unsigned                    early_preread:1;
+     unsigned                    write_blocked:1;
++
++    ngx_str_t                   fp_ja3_data;
++    ngx_str_t                   fp_ja3_str;
++    ngx_str_t                   fp_ja3_hash;
++    uint16_t                    fp_tls_greased;
+ };
+ 
+ 
+diff --git a/src/http/v2/ngx_http_v2.c b/src/http/v2/ngx_http_v2.c
+index 0f5bd3de8..1b85e378d 100644
+--- a/src/http/v2/ngx_http_v2.c
++++ b/src/http/v2/ngx_http_v2.c
+@@ -301,6 +301,8 @@ ngx_http_v2_init(ngx_event_t *rev)
+         ngx_add_timer(rev, cscf->client_header_timeout);
+     }
+ 
++    h2c->fp_fingerprinted = 0;
++
+     c->idle = 1;
+     ngx_reusable_connection(c, 0);
+ 
+@@ -1352,6 +1354,14 @@ ngx_http_v2_state_headers(ngx_http_v2_connection_t *h2c, u_char *pos,
+         }
+     }
+ 
++    if (!h2c->fp_fingerprinted && h2c->fp_priorities.len < 32) {
++        h2c->fp_priorities.data[h2c->fp_priorities.len] = (uint8_t)stream->node->id;
++        h2c->fp_priorities.data[h2c->fp_priorities.len+1] = (uint8_t)excl;
++        h2c->fp_priorities.data[h2c->fp_priorities.len+2] = (uint8_t)depend;
++        h2c->fp_priorities.data[h2c->fp_priorities.len+3] = (uint8_t)(weight-1);
++        h2c->fp_priorities.len += 4;
++    }
++
+     return ngx_http_v2_state_header_block(h2c, pos, end);
+ 
+ rst_stream:
+@@ -1775,6 +1785,9 @@ ngx_http_v2_state_process_header(ngx_http_v2_connection_t *h2c, u_char *pos,
+     }
+ 
+     if (header->name.data[0] == ':') {
++        if (!h2c->fp_fingerprinted && h2c->fp_pseudoheaders.len < 32 && header->name.len > 1)
++            h2c->fp_pseudoheaders.data[h2c->fp_pseudoheaders.len++] = header->name.data[1];
++
+         rc = ngx_http_v2_pseudo_header(r, header);
+ 
+         if (rc == NGX_OK) {
+@@ -2194,6 +2207,12 @@ ngx_http_v2_state_settings_params(ngx_http_v2_connection_t *h2c, u_char *pos,
+         ngx_log_debug2(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
+                        "http2 setting %ui:%ui", id, value);
+ 
++        if (!h2c->fp_fingerprinted && h2c->fp_settings.len < 32) {
++            h2c->fp_settings.data[h2c->fp_settings.len] = (uint8_t)id;
++            *(uint32_t*)(h2c->fp_settings.data + h2c->fp_settings.len + 1)  = (uint32_t)value;
++            h2c->fp_settings.len += 5;
++        }
++
+         switch (id) {
+ 
+         case NGX_HTTP_V2_INIT_WINDOW_SIZE_SETTING:
+@@ -2478,6 +2497,9 @@ ngx_http_v2_state_window_update(ngx_http_v2_connection_t *h2c, u_char *pos,
+     }
+ 
+     h2c->send_window += window;
++    if (!h2c->fp_fingerprinted) {
++        h2c->fp_windowupdate = window;
++    }
+ 
+     while (!ngx_queue_empty(&h2c->waiting)) {
+         q = ngx_queue_head(&h2c->waiting);
+diff --git a/src/http/v2/ngx_http_v2.h b/src/http/v2/ngx_http_v2.h
+index 6751b3026..60a68a0fd 100644
+--- a/src/http/v2/ngx_http_v2.h
++++ b/src/http/v2/ngx_http_v2.h
+@@ -17,6 +17,8 @@
+ 
+ #define NGX_HTTP_V2_STATE_BUFFER_SIZE    16
+ 
++#define NGX_FP_V2_BUFFER_SIZE            32
++
+ #define NGX_HTTP_V2_DEFAULT_FRAME_SIZE   (1 << 14)
+ #define NGX_HTTP_V2_MAX_FRAME_SIZE       ((1 << 24) - 1)
+ 
+@@ -121,6 +123,12 @@ typedef struct {
+ } ngx_http_v2_hpack_t;
+ 
+ 
++typedef struct {
++  u_char data[NGX_FP_V2_BUFFER_SIZE];
++  size_t len;
++} ngx_http_v2_fp_fixed_str_t;
++
++
+ struct ngx_http_v2_connection_s {
+     ngx_connection_t                *connection;
+     ngx_http_connection_t           *http_connection;
+@@ -168,6 +176,13 @@ struct ngx_http_v2_connection_s {
+     unsigned                         table_update:1;
+     unsigned                         blocked:1;
+     unsigned                         goaway:1;
++
++    unsigned                         fp_fingerprinted:1;
++    ngx_http_v2_fp_fixed_str_t       fp_settings,
++                                     fp_priorities,
++                                     fp_pseudoheaders;
++    ngx_uint_t                       fp_windowupdate;
++    ngx_str_t                        fp_str;
+ };
+ 
+ 

--- a/patches/openssl.openssl-3.4.patch
+++ b/patches/openssl.openssl-3.4.patch
@@ -1,0 +1,186 @@
+diff --git a/include/openssl/ssl.h.in b/include/openssl/ssl.h.in
+index 4bab2ac767..9732ece423 100644
+--- a/include/openssl/ssl.h.in
++++ b/include/openssl/ssl.h.in
+@@ -1905,6 +1905,8 @@ size_t SSL_client_hello_get0_ciphers(SSL *s, const unsigned char **out);
+ size_t SSL_client_hello_get0_compression_methods(SSL *s,
+                                                  const unsigned char **out);
+ int SSL_client_hello_get1_extensions_present(SSL *s, int **out, size_t *outlen);
++size_t SSL_client_hello_get_ja3_data(SSL *s, unsigned char *data,
++                                     size_t data_size);
+ int SSL_client_hello_get_extension_order(SSL *s, uint16_t *exts,
+                                          size_t *num_exts);
+ int SSL_client_hello_get0_ext(SSL *s, unsigned int type,
+diff --git a/include/openssl/tls1.h b/include/openssl/tls1.h
+index 8e9b110bb3..3a2407b0e4 100644
+--- a/include/openssl/tls1.h
++++ b/include/openssl/tls1.h
+@@ -142,6 +142,13 @@ extern "C" {
+ /* ExtensionType value from RFC7627 */
+ # define TLSEXT_TYPE_extended_master_secret      23
+ 
++/* ExtensionType value from RFC6961 */
++# define TLSEXT_TYPE_status_request_v2           17
++/* ExtensionType value from RFC8449 */
++# define TLSEXT_TYPE_record_size_limit           28
++/* ExtensionType value from RFC7639 */
++# define TLSEXT_TYPE_application_settings        17513
++
+ /* ExtensionType value from RFC8879 */
+ # define TLSEXT_TYPE_compress_certificate        27
+ 
+diff --git a/ssl/ssl_lib.c b/ssl/ssl_lib.c
+index 295b719ff2..429d710fa2 100644
+--- a/ssl/ssl_lib.c
++++ b/ssl/ssl_lib.c
+@@ -6641,6 +6641,101 @@ int SSL_client_hello_get1_extensions_present(SSL *s, int **out, size_t *outlen)
+     return 0;
+ }
+ 
++size_t SSL_client_hello_get_ja3_data(SSL *s, unsigned char *data,
++        size_t data_size)
++{
++    RAW_EXTENSION *ext;
++    PACKET *groups = NULL, *formats = NULL;
++    size_t num = 0, i;
++    unsigned char *ptr = data,
++                  *end = data + data_size;
++    const SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(s);
++
++    if (sc == NULL)
++        return 0;
++
++    if (ossl_unlikely(sc->clienthello == NULL || data == NULL
++                /** just checking that we have at least this */
++                || data_size < 128))
++        return 0;
++
++    /* version */
++    *(uint16_t *) ptr = (uint16_t) sc->clienthello->legacy_version;
++    ptr += sizeof(uint16_t);
++
++    num = PACKET_remaining(&sc->clienthello->ciphersuites);
++    *(uint16_t *) ptr = (uint16_t) num;
++    ptr += sizeof(uint16_t);
++
++    if (ossl_unlikely(ptr + num > end))
++        return 0;
++
++    memcpy(ptr, PACKET_data(&sc->clienthello->ciphersuites), num);
++    ptr += num;
++
++    /* extensions */
++    num = 0;
++    for (i = 0; i < sc->clienthello->pre_proc_exts_len; i++) {
++        ext = sc->clienthello->pre_proc_exts + i;
++        if (ext->present)
++            num++;
++    }
++
++    num = num * 2;
++    if (ossl_unlikely((ptr + num + sizeof(uint16_t)) > end))
++        return 0;
++    *(uint16_t*) ptr = (uint16_t) num;
++    ptr += sizeof(uint16_t);
++
++    for (i = 0; i < sc->clienthello->pre_proc_exts_len; i++) {
++        ext = sc->clienthello->pre_proc_exts + i;
++        if (ext->present) {
++            if (ext->received_order >= num)
++                break;
++            if (ext->type == TLSEXT_TYPE_supported_groups)
++                groups = &ext->data;
++            if (ext->type == TLSEXT_TYPE_ec_point_formats)
++                formats = &ext->data;
++            if (ossl_likely(ext->received_order < data_size)) {
++                *(uint16_t*)(ptr + ext->received_order) = (uint16_t) ext->type;
++            }
++        }
++    }
++
++    ptr += num;
++     /* groups */
++    if (groups) {
++        num = PACKET_remaining(groups);
++        if (ossl_unlikely((ptr + num + sizeof(uint16_t)) > end))
++            return 0;
++        memcpy(ptr, PACKET_data(groups), num);
++        *(uint16_t*) ptr = (uint16_t) num;
++        ptr += num;
++    } else {
++        if (ossl_unlikely(ptr + sizeof(uint16_t) > end))
++            return 0;
++        *(uint16_t *) ptr = (uint16_t) 0;
++        ptr += sizeof(uint16_t);
++    }
++
++    /* formats */
++    if (formats) {
++        num = PACKET_remaining(formats);
++        if (ossl_unlikely((ptr + num + sizeof(uint8_t)) > end))
++            return 0;
++        memcpy(ptr, PACKET_data(formats), num);
++        *(uint8_t *) ptr = (uint8_t) num;
++        ptr += num;
++    } else {
++        if (ossl_unlikely(ptr + sizeof(uint8_t) > end))
++            return 0;
++        *(uint8_t *) ptr = (uint8_t) 0;
++        ptr += sizeof(uint8_t);
++    }
++
++    return ptr - data;
++}
++
+ int SSL_client_hello_get_extension_order(SSL *s, uint16_t *exts, size_t *num_exts)
+ {
+     RAW_EXTENSION *ext;
+diff --git a/ssl/ssl_local.h b/ssl/ssl_local.h
+index 277be3084d..6b3821737f 100644
+--- a/ssl/ssl_local.h
++++ b/ssl/ssl_local.h
+@@ -701,6 +701,9 @@ typedef enum tlsext_index_en {
+     TLSEXT_IDX_compress_certificate,
+     TLSEXT_IDX_early_data,
+     TLSEXT_IDX_certificate_authorities,
++    TLSEXT_IDX_status_request_v2,
++    TLSEXT_IDX_record_size_limit,
++    TLSEXT_IDX_application_settings,
+     TLSEXT_IDX_padding,
+     TLSEXT_IDX_psk,
+     /* Dummy index - must always be the last entry */
+diff --git a/ssl/statem/extensions.c b/ssl/statem/extensions.c
+index 762c7ac0d4..56d2f5ba60 100644
+--- a/ssl/statem/extensions.c
++++ b/ssl/statem/extensions.c
+@@ -413,6 +413,30 @@ static const EXTENSION_DEFINITION ext_defs[] = {
+         tls_construct_certificate_authorities,
+         tls_construct_certificate_authorities, NULL,
+     },
++    {
++        TLSEXT_TYPE_status_request_v2,
++        SSL_EXT_CLIENT_HELLO,
++        NULL,
++        NULL, NULL,
++        NULL,
++        NULL, NULL,
++    },
++    {
++        TLSEXT_TYPE_record_size_limit,
++        SSL_EXT_CLIENT_HELLO,
++        NULL,
++        NULL, NULL,
++        NULL,
++        NULL, NULL,
++    },
++    {
++        TLSEXT_TYPE_application_settings,
++        SSL_EXT_CLIENT_HELLO,
++        NULL,
++        NULL, NULL,
++        NULL,
++        NULL, NULL,
++    },
+     {
+         /* Must be immediately before pre_shared_key */
+         TLSEXT_TYPE_padding,

--- a/patches/openssl.openssl-3.4.patch
+++ b/patches/openssl.openssl-3.4.patch
@@ -30,10 +30,10 @@ index 8e9b110bb3..3a2407b0e4 100644
  # define TLSEXT_TYPE_compress_certificate        27
  
 diff --git a/ssl/ssl_lib.c b/ssl/ssl_lib.c
-index 295b719ff2..429d710fa2 100644
+index 295b719ff2..3d92df0db1 100644
 --- a/ssl/ssl_lib.c
 +++ b/ssl/ssl_lib.c
-@@ -6641,6 +6641,101 @@ int SSL_client_hello_get1_extensions_present(SSL *s, int **out, size_t *outlen)
+@@ -6641,6 +6641,106 @@ int SSL_client_hello_get1_extensions_present(SSL *s, int **out, size_t *outlen)
      return 0;
  }
  
@@ -59,15 +59,18 @@ index 295b719ff2..429d710fa2 100644
 +    *(uint16_t *) ptr = (uint16_t) sc->clienthello->legacy_version;
 +    ptr += sizeof(uint16_t);
 +
++    /* ciphers */
 +    num = PACKET_remaining(&sc->clienthello->ciphersuites);
-+    *(uint16_t *) ptr = (uint16_t) num;
-+    ptr += sizeof(uint16_t);
++    if (ossl_likely(num > 0)) {
++        *(uint16_t *) ptr = (uint16_t) num;
++        ptr += sizeof(uint16_t);
 +
-+    if (ossl_unlikely(ptr + num > end))
-+        return 0;
++        if (ossl_unlikely(ptr + num > end))
++            return 0;
 +
-+    memcpy(ptr, PACKET_data(&sc->clienthello->ciphersuites), num);
-+    ptr += num;
++        memcpy(ptr, PACKET_data(&sc->clienthello->ciphersuites), num);
++        ptr += num;
++    }
 +
 +    /* extensions */
 +    num = 0;
@@ -99,9 +102,11 @@ index 295b719ff2..429d710fa2 100644
 +    }
 +
 +    ptr += num;
-+     /* groups */
-+    if (groups) {
-+        num = PACKET_remaining(groups);
++
++    /* groups */
++    num = PACKET_remaining(groups);
++    if (groups && num > 0) {
++
 +        if (ossl_unlikely((ptr + num + sizeof(uint16_t)) > end))
 +            return 0;
 +        memcpy(ptr, PACKET_data(groups), num);
@@ -115,8 +120,8 @@ index 295b719ff2..429d710fa2 100644
 +    }
 +
 +    /* formats */
-+    if (formats) {
-+        num = PACKET_remaining(formats);
++    num = PACKET_remaining(formats);
++    if (formats && num > 0) {
 +        if (ossl_unlikely((ptr + num + sizeof(uint8_t)) > end))
 +            return 0;
 +        memcpy(ptr, PACKET_data(formats), num);

--- a/src/nginx_ssl_fingerprint.c
+++ b/src/nginx_ssl_fingerprint.c
@@ -211,6 +211,11 @@ int ngx_ssl_ja3(ngx_connection_t *c)
 
     c->ssl->fp_ja3_str.len = c->ssl->fp_ja3_data.len * 3;
     c->ssl->fp_ja3_str.data = ngx_pnalloc(c->pool, c->ssl->fp_ja3_str.len);
+    if (c->ssl->fp_ja3_str.data == NULL) {
+        /** Else we break a data stream */
+        c->ssl->fp_ja3_str.len = 0;
+        return NGX_DECLINED;
+    }
 
     ngx_log_debug(NGX_LOG_DEBUG_EVENT, c->log, 0, "ngx_ssl_ja3: alloc bytes: [%d]\n", c->ssl->fp_ja3_str.len);
 
@@ -313,6 +318,11 @@ int ngx_ssl_ja3_hash(ngx_connection_t *c)
 
     c->ssl->fp_ja3_hash.len = 32;
     c->ssl->fp_ja3_hash.data = ngx_pnalloc(c->pool, c->ssl->fp_ja3_hash.len);
+    if (c->ssl->fp_ja3_hash.data == NULL) {
+        /** Else we break a stream */
+        c->ssl->fp_ja3_hash.len = 0;
+        return NGX_DECLINED;
+    }
 
     ngx_log_debug(NGX_LOG_DEBUG_EVENT, c->log, 0, "ngx_ssl_ja3_hash: alloc bytes: [%d]\n", c->ssl->fp_ja3_hash.len);
 
@@ -343,6 +353,10 @@ int ngx_http2_fingerprint(ngx_connection_t *c, ngx_http_v2_connection_t *h2c)
 
     n = 4 + h2c->fp_settings.len * 3 + 10 + h2c->fp_priorities.len * 2 + h2c->fp_pseudoheaders.len * 2;
     h2c->fp_str.data = ngx_pnalloc(c->pool, n);
+    if (h2c->fp_str.data == NULL) {
+        /** Else we break a stream */
+        return NGX_DECLINED;
+    }
     pstr = h2c->fp_str.data;
 
     ngx_log_debug(NGX_LOG_DEBUG_EVENT, c->log, 0, "ngx_http2_fingerprint: alloc bytes: [%d]\n", n);

--- a/src/nginx_ssl_fingerprint.h
+++ b/src/nginx_ssl_fingerprint.h
@@ -1,0 +1,19 @@
+
+/*
+ * Obj: nginx_ssl_fingerprint.c
+ */
+
+#ifndef NGINX_SSL_FINGERPRINT_H_
+#define NGINX_SSL_FINGERPRINT_H_ 1
+
+
+#include <ngx_config.h>
+#include <ngx_core.h>
+#include <ngx_http.h>
+
+int ngx_ssl_ja3(ngx_connection_t *c);
+int ngx_ssl_ja3_hash(ngx_connection_t *c);
+int ngx_http2_fingerprint(ngx_connection_t *c, ngx_http_v2_connection_t *h2c);
+
+#endif /** NGINX_SSL_FINGERPRINT_H_ */
+

--- a/src/ngx_http_ssl_fingerprint_module.c
+++ b/src/ngx_http_ssl_fingerprint_module.c
@@ -1,61 +1,71 @@
+
 #include <ngx_config.h>
 #include <ngx_core.h>
 #include <ngx_http.h>
 
-extern int ngx_ssl_ja3(ngx_connection_t *c);
-extern int ngx_ssl_ja3_hash(ngx_connection_t *c);
-extern int ngx_http2_fingerprint(ngx_connection_t *c, ngx_http_v2_connection_t *h2c);
+#include <nginx_ssl_fingerprint.h>
 
 static ngx_int_t ngx_http_ssl_fingerprint_init(ngx_conf_t *cf);
+static ngx_int_t ngx_http_ssl_greased(ngx_http_request_t *r,
+                            ngx_http_variable_value_t *v, uintptr_t data);
+static ngx_int_t ngx_http_ssl_fingerprint(ngx_http_request_t *r,
+                            ngx_http_variable_value_t *v, uintptr_t data);
+static ngx_int_t ngx_http_ssl_fingerprint_hash(ngx_http_request_t *r,
+                             ngx_http_variable_value_t *v, uintptr_t data);
+static ngx_int_t ngx_http_http2_fingerprint(ngx_http_request_t *r,
+                            ngx_http_variable_value_t *v, uintptr_t data);
 
 static ngx_http_module_t ngx_http_ssl_fingerprint_module_ctx = {
-    NULL,                  /* preconfiguration */
-    ngx_http_ssl_fingerprint_init, /* postconfiguration */
-    NULL,                  /* create main configuration */
-    NULL,                  /* init main configuration */
-    NULL,                  /* create server configuration */
-    NULL,                  /* merge server configuration */
-    NULL,                  /* create location configuration */
-    NULL                   /* merge location configuration */
+    ngx_http_ssl_fingerprint_init,  /* preconfiguration */
+    NULL,                           /* postconfiguration */
+    NULL,                           /* create main configuration */
+    NULL,                           /* init main configuration */
+    NULL,                           /* create server configuration */
+    NULL,                           /* merge server configuration */
+    NULL,                           /* create location configuration */
+    NULL                            /* merge location configuration */
 };
 
 ngx_module_t ngx_http_ssl_fingerprint_module = {
     NGX_MODULE_V1,
     &ngx_http_ssl_fingerprint_module_ctx, /* module context */
-    NULL,                         /* module directives */
-    NGX_HTTP_MODULE,              /* module type */
-    NULL,                         /* init master */
-    NULL,                         /* init module */
-    NULL,                         /* init process */
-    NULL,                         /* init thread */
-    NULL,                         /* exit thread */
-    NULL,                         /* exit process */
-    NULL,                         /* exit master */
+    NULL,                                 /* module directives */
+    NGX_HTTP_MODULE,                      /* module type */
+    NULL,                                 /* init master */
+    NULL,                                 /* init module */
+    NULL,                                 /* init process */
+    NULL,                                 /* init thread */
+    NULL,                                 /* exit thread */
+    NULL,                                 /* exit process */
+    NULL,                                 /* exit master */
     NGX_MODULE_V1_PADDING};
 
+static ngx_http_variable_t ngx_http_ssl_fingerprint_variables_list[] = {
+    {ngx_string("http_ssl_greased"), NULL, ngx_http_ssl_greased,
+     0, NGX_HTTP_VAR_NOCACHEABLE, 0},
+    {ngx_string("http_ssl_ja3"), NULL, ngx_http_ssl_fingerprint,
+     0, NGX_HTTP_VAR_NOCACHEABLE, 0},
+    {ngx_string("http_ssl_ja3_hash"), NULL, ngx_http_ssl_fingerprint_hash,
+     0, NGX_HTTP_VAR_NOCACHEABLE, 0},
+    {ngx_string("http2_fingerprint"), NULL, ngx_http_http2_fingerprint,
+     0, NGX_HTTP_VAR_NOCACHEABLE, 0},
+    ngx_http_null_variable
+};
 
 static ngx_int_t
 ngx_http_ssl_greased(ngx_http_request_t *r,
                  ngx_http_variable_value_t *v, uintptr_t data)
 {
-    if (r->connection == NULL)
-    {
-        return NGX_OK;
-    }
+    /* For access.log's map $http2_fingerpring {}:
+     * if it's not found, then user could add a defined string */
+    v->not_found = 1;
 
-    if (r->connection->ssl == NULL)
-    {
+    if (ngx_ssl_ja3(r->connection) != NGX_OK) {
         return NGX_OK;
-    }
-
-    if (ngx_ssl_ja3(r->connection) == NGX_DECLINED)
-    {
-        return NGX_ERROR;
     }
 
     v->len = 1;
-    v->data = (u_char*)(r->connection->ssl->fp_tls_greased ? "1" : "0");
-
+    v->data = (u_char*) (r->connection->ssl->fp_tls_greased ? "1" : "0");
     v->valid = 1;
     v->no_cacheable = 1;
     v->not_found = 0;
@@ -67,26 +77,19 @@ static ngx_int_t
 ngx_http_ssl_fingerprint(ngx_http_request_t *r,
                  ngx_http_variable_value_t *v, uintptr_t data)
 {
-    if (r->connection == NULL)
-    {
-        return NGX_OK;
-    }
+    /* For access.log's map $http2_fingerpring {}:
+     * if it's not found, then user could add a defined string */
+    v->not_found = 1;
 
-    if (r->connection->ssl == NULL)
-    {
+    if (ngx_ssl_ja3(r->connection) != NGX_OK) {
         return NGX_OK;
-    }
-
-    if (ngx_ssl_ja3(r->connection) == NGX_DECLINED)
-    {
-        return NGX_ERROR;
     }
 
     v->data = r->connection->ssl->fp_ja3_str.data;
     v->len = r->connection->ssl->fp_ja3_str.len;
-    v->valid = 1;
     v->no_cacheable = 1;
     v->not_found = 0;
+    v->valid = 1;
 
     return NGX_OK;
 }
@@ -95,26 +98,19 @@ static ngx_int_t
 ngx_http_ssl_fingerprint_hash(ngx_http_request_t *r,
                  ngx_http_variable_value_t *v, uintptr_t data)
 {
-    if (r->connection == NULL)
-    {
-        return NGX_OK;
-    }
+    /* For access.log's map $http2_fingerpring {}:
+     * if it's not found, then user could add a defined string */
+    v->not_found = 1;
 
-    if (r->connection->ssl == NULL)
-    {
+    if (ngx_ssl_ja3_hash(r->connection) != NGX_OK) {
         return NGX_OK;
-    }
-
-    if (ngx_ssl_ja3_hash(r->connection) == NGX_DECLINED)
-    {
-        return NGX_ERROR;
     }
 
     v->data = r->connection->ssl->fp_ja3_hash.data;
     v->len = r->connection->ssl->fp_ja3_hash.len;
-    v->valid = 1;
     v->no_cacheable = 1;
     v->not_found = 0;
+    v->valid = 1;
 
     return NGX_OK;
 }
@@ -123,77 +119,45 @@ static ngx_int_t
 ngx_http_http2_fingerprint(ngx_http_request_t *r,
                  ngx_http_variable_value_t *v, uintptr_t data)
 {
-    if (r->connection == NULL)
-    {
+    /* For access.log's map $http2_fingerpring {}:
+     * if it's not found, then user could add a defined string */
+    v->not_found = 1;
+
+    if (r->stream == NULL) {
         return NGX_OK;
     }
 
-    if (r->stream == NULL)
+    if (ngx_http2_fingerprint(r->connection, r->stream->connection)
+            != NGX_OK)
     {
         return NGX_OK;
-    }
-
-    if (r->stream->connection == NULL)
-    {
-        return NGX_OK;
-    }
-
-    if (ngx_http2_fingerprint(r->connection, r->stream->connection) == NGX_DECLINED)
-    {
-        return NGX_ERROR;
     }
 
     v->data = r->stream->connection->fp_str.data;
     v->len = r->stream->connection->fp_str.len;
     v->valid = 1;
-    v->no_cacheable = 1;
     v->not_found = 0;
+    v->no_cacheable = 1;
 
     return NGX_OK;
 }
-
-static ngx_http_variable_t ngx_http_ssl_fingerprint_variables_list[] = {
-    {ngx_string("http_ssl_greased"),
-     NULL,
-     ngx_http_ssl_greased,
-     0, 0, 0},
-    {ngx_string("http_ssl_ja3"),
-     NULL,
-     ngx_http_ssl_fingerprint,
-     0, 0, 0},
-    {ngx_string("http_ssl_ja3_hash"),
-     NULL,
-     ngx_http_ssl_fingerprint_hash,
-     0, 0, 0},
-    {ngx_string("http2_fingerprint"),
-     NULL,
-     ngx_http_http2_fingerprint,
-     0, 0, 0},
-};
 
 static ngx_int_t
 ngx_http_ssl_fingerprint_init(ngx_conf_t *cf)
 {
+    ngx_http_variable_t  *var, *v;
 
-    ngx_http_variable_t *v;
-    size_t l = 0;
-    size_t vars_len;
+    for (v = ngx_http_ssl_fingerprint_variables_list; v->name.len; v++) {
 
-    vars_len = (sizeof(ngx_http_ssl_fingerprint_variables_list) /
-                sizeof(ngx_http_ssl_fingerprint_variables_list[0]));
-
-    /* Register variables */
-    for (l = 0; l < vars_len; ++l)
-    {
-        v = ngx_http_add_variable(cf,
-                                  &ngx_http_ssl_fingerprint_variables_list[l].name,
-                                  ngx_http_ssl_fingerprint_variables_list[l].flags);
-        if (v == NULL)
-        {
-            continue;
+        var = ngx_http_add_variable(cf, &v->name, v->flags);
+        if (var == NULL) {
+            return NGX_ERROR;
         }
-        *v = ngx_http_ssl_fingerprint_variables_list[l];
+        /** NOTE: update it, if set_handler will be needed */
+        var->get_handler = v->get_handler;
+        var->data = v->data;
     }
 
     return NGX_OK;
 }
+


### PR DESCRIPTION
#### Issue: https://github.com/phuslu/nginx-ssl-fingerprint/issues/51

#### Issues fixes:
- Fixed https://github.com/phuslu/nginx-ssl-fingerprint/issues/51; awaiting for testing that will be btw Feb 3 - Feb 5. Until test please do not merge it.
- Fixed initialization of the variables. Current implementation can break Nginx's logic since it do not handle NGX_ERROR and overwrite `v`. Reference:  https://github.com/nginx/nginx/blob/master/src/http/modules/ngx_http_stub_status_module.c#L35, https://github.com/nginx/nginx/blob/master/src/http/modules/ngx_http_stub_status_module.c#L205
- Fixes ngx_*alloc error handling. ngx_*allocation functions can return NULL, if no free space (slabs). The typical reaction should be do not do anything.

#### Improvements:
- The module variables could be used with different nginx.conf's features like map (i.e. not_found changes).
- Made HTTP module more close to original Nginx's defined logic.
- Increased patch version to OpenSSL 3.4 and to NGINX 1.27.
- Increased performance by reducing memory allocations (using pre-redefined sizes with range control) and by using likely/unlikely pattern in the openssl patch.

Btw the question: I can see that I could increase stream module as well. But I need time to that, since we are in middle to integration of this module and we need http. Do you need a help here?