### PR TITLE
Fix heap-buffer-overflow in JA3 and H2 fingerprint formatting

### DIFF
--- a/src/nginx_ssl_fingerprint.c
+++ b/src/nginx_ssl_fingerprint.c
@@ -221,7 +221,7 @@ int ngx_ssl_ja3(ngx_connection_t *c)
         return NGX_OK;
     }
 
-    c->ssl->fp_ja3_str.len = c->ssl->fp_ja3_data.len * 3;
+    c->ssl->fp_ja3_str.len = c->ssl->fp_ja3_data.len * 4;
     c->ssl->fp_ja3_str.data = ngx_pnalloc(c->pool, c->ssl->fp_ja3_str.len);
     if (c->ssl->fp_ja3_str.data == NULL) {
         /** Else we break a data stream */
@@ -368,7 +368,7 @@ int ngx_http2_fingerprint(ngx_connection_t *c, ngx_http_v2_connection_t *h2c)
     }
 
     n = 4 + h2c->fp_settings.len * 3
-        + 10 + h2c->fp_priorities.len * 2
+        + 10 + h2c->fp_priorities.len * 4
         + h2c->fp_pseudoheaders.len * 2;
 
     h2c->fp_str.data = ngx_pnalloc(c->pool, n);


### PR DESCRIPTION
## Summary

Fixes two remotely-triggerable heap-buffer-overflow bugs in fingerprint string formatting.

- **JA3** (line 224): buffer multiplier `* 3` → `* 4` — each byte can expand to 4 chars (e.g. `255` → `"255-"`)
- **H2 priorities** (line 371): buffer multiplier `* 2` → `* 4` — each 4-byte record can expand to 16 chars (e.g. `"255:1:255:256,"`)

Fixes #68

## ASAN test suite

Reproduction with AddressSanitizer: https://github.com/hsw/nginx-ssl-fingerprint/tree/test/ja3-overflow/tests

```sh
cd tests
docker compose up --build --abort-on-container-exit
```

- **Before fix:** 17+ ASAN heap-buffer-overflow errors on JA3, 3 on H2
- **After fix:** zero ASAN errors, all requests processed correctly