### PR TITLE
fix: OOB read in JA3 groups loop and defensive error handling in variable handlers

### DIFF
--- a/src/nginx_ssl_fingerprint.c
+++ b/src/nginx_ssl_fingerprint.c
@@ -273,7 +273,7 @@ int ngx_ssl_ja3(ngx_connection_t *c)
 
     /* groups */
     num = *(uint16_t*)data;
-    for (i = 2; i < num; i += 2) {
+    for (i = 2; i + 1 < num; i += 2) {
         n = ((uint16_t)data[i]) << 8 | ((uint16_t)data[i+1]);
         if (!IS_GREASE_CODE(n)) {
             ptr = append_uint16(ptr, n);

--- a/src/ngx_http_ssl_fingerprint_module.c
+++ b/src/ngx_http_ssl_fingerprint_module.c
@@ -65,7 +65,7 @@ ngx_http_ssl_greased(ngx_http_request_t *r,
     }
 
     if (ngx_ssl_ja3(r->connection) != NGX_OK) {
-        return NGX_ERROR;
+        return NGX_OK;
     }
 
     v->len = 1;
@@ -88,7 +88,7 @@ ngx_http_ssl_fingerprint(ngx_http_request_t *r,
     }
 
     if (ngx_ssl_ja3(r->connection) != NGX_OK) {
-        return NGX_ERROR;
+        return NGX_OK;
     }
 
     v->data = r->connection->ssl->fp_ja3_str.data;
@@ -136,7 +136,7 @@ ngx_http_http2_fingerprint(ngx_http_request_t *r,
     if (ngx_http2_fingerprint(r->connection, r->stream->connection)
             != NGX_OK)
     {
-        return NGX_ERROR;
+        return NGX_OK;
     }
 
     v->data = r->stream->connection->fp_str.data;

--- a/src/ngx_stream_ssl_fingerprint_preread_module.c
+++ b/src/ngx_stream_ssl_fingerprint_preread_module.c
@@ -42,6 +42,8 @@ static ngx_int_t
 ngx_stream_ssl_greased(ngx_stream_session_t *s,
                  ngx_stream_variable_value_t *v, uintptr_t data)
 {
+    v->not_found = 1;
+
     if (s->connection == NULL)
     {
         return NGX_OK;
@@ -52,9 +54,9 @@ ngx_stream_ssl_greased(ngx_stream_session_t *s,
         return NGX_OK;
     }
 
-    if (ngx_ssl_ja3(s->connection) == NGX_DECLINED)
+    if (ngx_ssl_ja3(s->connection) != NGX_OK)
     {
-        return NGX_ERROR;
+        return NGX_OK;
     }
 
     v->len = 1;
@@ -71,6 +73,8 @@ static ngx_int_t
 ngx_stream_ssl_fingerprint(ngx_stream_session_t *s,
                  ngx_stream_variable_value_t *v, uintptr_t data)
 {
+    v->not_found = 1;
+
     if (s->connection == NULL)
     {
         return NGX_OK;
@@ -81,9 +85,9 @@ ngx_stream_ssl_fingerprint(ngx_stream_session_t *s,
         return NGX_OK;
     }
 
-    if (ngx_ssl_ja3(s->connection) == NGX_DECLINED)
+    if (ngx_ssl_ja3(s->connection) != NGX_OK)
     {
-        return NGX_ERROR;
+        return NGX_OK;
     }
 
     v->data = s->connection->ssl->fp_ja3_str.data;
@@ -99,6 +103,8 @@ static ngx_int_t
 ngx_stream_ssl_fingerprint_hash(ngx_stream_session_t *s,
                  ngx_stream_variable_value_t *v, uintptr_t data)
 {
+    v->not_found = 1;
+
     if (s->connection == NULL)
     {
         return NGX_OK;
@@ -109,9 +115,9 @@ ngx_stream_ssl_fingerprint_hash(ngx_stream_session_t *s,
         return NGX_OK;
     }
 
-    if (ngx_ssl_ja3_hash(s->connection) == NGX_DECLINED)
+    if (ngx_ssl_ja3_hash(s->connection) != NGX_OK)
     {
-        return NGX_ERROR;
+        return NGX_OK;
     }
 
     v->data = s->connection->ssl->fp_ja3_hash.data;


### PR DESCRIPTION
Fixes #70.

## Changes

### 1. OOB read in groups loop (`nginx_ssl_fingerprint.c:276`)

`i < num` → `i + 1 < num` — prevents 1-byte past-buffer read on odd-length `supported_groups`. `client_hello_cb` fires before OpenSSL validates extension content (`statem_srvr.c:1739` vs `extensions_srvr.c:1223`). ASan-confirmed: see #70.

Note: the ciphers loop (`i <= num`) uses a different encoding (`num` excludes the 2-byte length prefix, `data += 2 + num`), so it is not affected.

### 2. Stream handler safety (`ngx_stream_ssl_fingerprint_preread_module.c`)

- `== NGX_DECLINED` → `!= NGX_OK` — dead code: no function in `src/` returns `NGX_DECLINED`. When `ngx_ssl_ja3()` returned `NGX_ERROR`, execution fell through to read potentially NULL `fp_ja3_str.data`.
- Add `v->not_found = 1` at the top of each handler, matching HTTP module pattern (added in ccfe8f1).
- `return NGX_ERROR` → `return NGX_OK` — a missing fingerprint should not abort the session. Matches `ja3_hash` HTTP handler which already returned `NGX_OK`.

### 3. HTTP handler safety (`ngx_http_ssl_fingerprint_module.c`)

- `return NGX_ERROR` → `return NGX_OK` in 3 handlers (`greased`, `ja3`, `h2`). The `ja3_hash` handler already returned `NGX_OK`. All handlers already set `v->not_found = 1` at the top.

```
 src/nginx_ssl_fingerprint.c                     |  2 +-
 src/ngx_http_ssl_fingerprint_module.c           |  6 +++---
 src/ngx_stream_ssl_fingerprint_preread_module.c | 18 ++++++++++++------
 3 files changed, 16 insertions(+), 10 deletions(-)
```