### PR TITLE
fix: enable variable caching for fingerprint variables

### DIFF
--- a/src/ngx_http_ssl_fingerprint_module.c
+++ b/src/ngx_http_ssl_fingerprint_module.c
@@ -42,13 +42,13 @@ ngx_module_t ngx_http_ssl_fingerprint_module = {
 
 static ngx_http_variable_t ngx_http_ssl_fingerprint_variables_list[] = {
     {ngx_string("http_ssl_greased"), NULL, ngx_http_ssl_greased,
-     0, NGX_HTTP_VAR_NOCACHEABLE, 0},
+     0, 0, 0},
     {ngx_string("http_ssl_ja3"), NULL, ngx_http_ssl_fingerprint,
-     0, NGX_HTTP_VAR_NOCACHEABLE, 0},
+     0, 0, 0},
     {ngx_string("http_ssl_ja3_hash"), NULL, ngx_http_ssl_fingerprint_hash,
-     0, NGX_HTTP_VAR_NOCACHEABLE, 0},
+     0, 0, 0},
     {ngx_string("http2_fingerprint"), NULL, ngx_http_http2_fingerprint,
-     0, NGX_HTTP_VAR_NOCACHEABLE, 0},
+     0, 0, 0},
     ngx_http_null_variable
 };
 
@@ -71,6 +71,7 @@ ngx_http_ssl_greased(ngx_http_request_t *r,
     v->len = 1;
     v->data = (u_char*) (r->connection->ssl->fp_tls_greased ? "1" : "0");
     v->not_found = 0;
+    v->valid = 1;
 
     return NGX_OK;
 }
@@ -94,6 +95,7 @@ ngx_http_ssl_fingerprint(ngx_http_request_t *r,
     v->data = r->connection->ssl->fp_ja3_str.data;
     v->len = r->connection->ssl->fp_ja3_str.len;
     v->not_found = 0;
+    v->valid = 1;
 
     return NGX_OK;
 }
@@ -117,6 +119,7 @@ ngx_http_ssl_fingerprint_hash(ngx_http_request_t *r,
     v->data = r->connection->ssl->fp_ja3_hash.data;
     v->len = r->connection->ssl->fp_ja3_hash.len;
     v->not_found = 0;
+    v->valid = 1;
 
     return NGX_OK;
 }
@@ -142,6 +145,7 @@ ngx_http_http2_fingerprint(ngx_http_request_t *r,
     v->data = r->stream->connection->fp_str.data;
     v->len = r->stream->connection->fp_str.len;
     v->not_found = 0;
+    v->valid = 1;
 
     return NGX_OK;
 }

--- a/src/ngx_stream_ssl_fingerprint_preread_module.c
+++ b/src/ngx_stream_ssl_fingerprint_preread_module.c
@@ -63,7 +63,6 @@ ngx_stream_ssl_greased(ngx_stream_session_t *s,
     v->data = (u_char*)(s->connection->ssl->fp_tls_greased ? "1" : "0");
 
     v->valid = 1;
-    v->no_cacheable = 1;
     v->not_found = 0;
 
     return NGX_OK;
@@ -93,7 +92,6 @@ ngx_stream_ssl_fingerprint(ngx_stream_session_t *s,
     v->data = s->connection->ssl->fp_ja3_str.data;
     v->len = s->connection->ssl->fp_ja3_str.len;
     v->valid = 1;
-    v->no_cacheable = 1;
     v->not_found = 0;
 
     return NGX_OK;
@@ -123,7 +121,6 @@ ngx_stream_ssl_fingerprint_hash(ngx_stream_session_t *s,
     v->data = s->connection->ssl->fp_ja3_hash.data;
     v->len = s->connection->ssl->fp_ja3_hash.len;
     v->valid = 1;
-    v->no_cacheable = 1;
     v->not_found = 0;
 
     return NGX_OK;


### PR DESCRIPTION
Fixes #72

## Summary

Fingerprint variables (`$http_ssl_ja3`, `$http_ssl_ja3_hash`, `$http_ssl_greased`, `$http2_fingerprint`) are immutable for the lifetime of a connection — their values come from the TLS ClientHello, which is fixed at handshake time. Despite this, handlers are called on every variable access because of two independent bugs.

## Problem

Three independent causes prevent nginx from caching fingerprint variable values:

### 1. `NGX_HTTP_VAR_NOCACHEABLE` flag (HTTP module)

All 4 HTTP variables are registered with `NGX_HTTP_VAR_NOCACHEABLE`. This tells nginx to never cache the result, calling the handler on every access. Core SSL variables (`$ssl_protocol`, `$ssl_cipher`) do not use this flag.

### 2. Missing `v->valid = 1` (HTTP module)

Even without `NOCACHEABLE`, nginx caches variables by condition `not_found || valid` (see `ngx_http_get_indexed_variable()`). Without `valid = 1`, the handler is called every time regardless of the flag.

### 3. Contradictory `v->no_cacheable = 1` (stream module)

Stream handlers set `v->valid = 1` (correct) but then immediately set `v->no_cacheable = 1`, which overrides the caching. The stream variable registration doesn't use `NOCACHEABLE`, so this `no_cacheable = 1` in the handler is the sole reason stream variables aren't cached.

## Impact

Tested with `$http_ssl_ja3_hash` used in `log_format`, `map`+`if`, `return`, and `proxy_set_header`:

| Scenario | Before | After |
|---|---|---|
| HTTP `ja3_hash`, 2 keep-alive requests | 12 handler calls | 2 (1 per request) |
| HTTP `greased`, 2 keep-alive requests | 8 handler calls | 2 (1 per request) |
| HTTP `ja3_hash`, single proxy request | 7 handler calls | 1 |
| Stream `ja3_hash`, single session | 2 handler calls | 1 |

The handler calls themselves are cheap (fingerprint is computed once and cached at the connection level). But with NOCACHEABLE, nginx also has to re-evaluate `map` blocks on every access, which adds overhead in configurations that use fingerprints for access control.

## Changes

### HTTP module (`src/ngx_http_ssl_fingerprint_module.c`)

- Removed `NGX_HTTP_VAR_NOCACHEABLE` from all 4 variable registrations
- Added `v->valid = 1` in all 4 handlers on the success path

### Stream module (`src/ngx_stream_ssl_fingerprint_preread_module.c`)

- Removed `v->no_cacheable = 1` from all 3 handlers

## Why this is safe

TLS fingerprints are derived from the ClientHello, which occurs once per TLS connection. The underlying data (`fp_ja3_str`, `fp_ja3_hash`, `fp_tls_greased`, `fp_str`) is already cached at the connection level in `c->ssl->fp_*` fields — the handler just copies pointers. Caching the nginx variable means the pointer copy happens once per request instead of N times.

For keep-alive connections, each HTTP request gets its own variable scope. `v->valid = 1` without `NOCACHEABLE` means the value is cached within a single request, not across requests. This is correct because the underlying connection (and its fingerprint) is the same.

## Test plan

### Debug handler-call count

Built with `--with-debug`, tested with `error_log debug`:

1. Config uses `$http_ssl_ja3_hash` in 4 places: `log_format`, `map`+`if`, `return`, `proxy_set_header`
2. Two HTTP requests on same keep-alive TLS connection via `curl -sk --http1.1 URL URL`
3. One stream request
4. Before fix: 12/8/7/2 handler calls; after fix: 2/2/1/1
5. Fingerprint values identical before and after

### Compatibility matrix (26 targets, ASan)

All combinations of nginx 1.20–1.29 × OpenSSL 1.1.1–3.4, built with `-fsanitize=address,undefined`:

- HTTP basic + `map{}` evaluation (`blocked=allow`)
- HTTP keep-alive: `ja3_hash` and `map` result consistent across 2 requests on same TLS connection
- Stream module: `ja3`, `ja3_hash` present, `map{}` resolves correctly
- No ASan crashes or memory errors

Result: **26/26 PASS** (10 checks each)

### Map evaluation with curl_cffi (26 targets)

Verifies `map{}` correctly evaluates `$http_ssl_ja3_hash` with caching enabled — tests the concern that `map` might see an empty variable if evaluated before the handler computes the hash.

- Phase 1: discover JA3 hashes from multiple browser profiles (chrome99, firefox135, safari18_0, edge99)
- Phase 2: `sed` one discovered hash into `map → "block"`, reload nginx, verify:
  - HTTP: matching profiles → 403, non-matching → 200
  - Stream: matching profiles → `blocked=block` in body, non-matching → `blocked=allow`
- Phase 3: keep-alive — hash and map result stable across 2 requests per connection

Result: **26/26 PASS** (35 checks each)

Relates to #61 (stream `map{}` issue).