### PR TITLE
Fix lossy id truncation, unaligned access, and empty-SETTINGS underflow in HTTP/2 fingerprint

### DIFF
--- a/patches/release-1.29.8.patch
+++ b/patches/release-1.29.8.patch
@@ -118,10 +118,10 @@ index efe2290..2891bc6 100644
          ngx_log_debug2(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
                         "http2 setting %ui:%ui", id, value);
  
-+        if (!h2c->fp_fingerprinted && h2c->fp_settings.len + 5 <= NGX_FP_V2_BUFFER_SIZE) {
-+            h2c->fp_settings.data[h2c->fp_settings.len] = (uint8_t)id;
-+            *(uint32_t*)(h2c->fp_settings.data + h2c->fp_settings.len + 1)  = (uint32_t)value;
-+            h2c->fp_settings.len += 5;
++        if (!h2c->fp_fingerprinted && h2c->fp_settings.len < NGX_FP_V2_SETTINGS_MAX) {
++            h2c->fp_settings.ids[h2c->fp_settings.len] = (uint16_t)id;
++            h2c->fp_settings.values[h2c->fp_settings.len] = (uint32_t)value;
++            h2c->fp_settings.len++;
 +        }
 +
          switch (id) {
@@ -141,16 +141,17 @@ diff --git a/src/http/v2/ngx_http_v2.h b/src/http/v2/ngx_http_v2.h
 index 9605c8a..026f3c7 100644
 --- a/src/http/v2/ngx_http_v2.h
 +++ b/src/http/v2/ngx_http_v2.h
-@@ -17,6 +17,8 @@
+@@ -17,6 +17,9 @@
  
  #define NGX_HTTP_V2_STATE_BUFFER_SIZE    16
  
 +#define NGX_FP_V2_BUFFER_SIZE            32
++#define NGX_FP_V2_SETTINGS_MAX           8
 +
  #define NGX_HTTP_V2_DEFAULT_FRAME_SIZE   (1 << 14)
  #define NGX_HTTP_V2_MAX_FRAME_SIZE       ((1 << 24) - 1)
  
-@@ -121,6 +123,12 @@ typedef struct {
+@@ -121,6 +124,18 @@ typedef struct {
  } ngx_http_v2_hpack_t;
  
  
@@ -159,19 +160,24 @@ index 9605c8a..026f3c7 100644
 +  size_t len;
 +} ngx_http_v2_fp_fixed_str_t;
 +
++typedef struct {
++  uint16_t   ids[NGX_FP_V2_SETTINGS_MAX];
++  uint32_t   values[NGX_FP_V2_SETTINGS_MAX];
++  ngx_uint_t len;
++} ngx_http_v2_fp_settings_t;
++
 +
  struct ngx_http_v2_connection_s {
      ngx_connection_t                *connection;
      ngx_http_connection_t           *http_connection;
-@@ -168,6 +176,13 @@ struct ngx_http_v2_connection_s {
+@@ -168,6 +183,12 @@ struct ngx_http_v2_connection_s {
      unsigned                         table_update:1;
      unsigned                         blocked:1;
      unsigned                         goaway:1;
 +
 +    unsigned                         fp_fingerprinted:1;
-+    ngx_http_v2_fp_fixed_str_t       fp_settings,
-+                                     fp_priorities,
-+                                     fp_pseudoheaders;
++    ngx_http_v2_fp_settings_t        fp_settings;
++    ngx_http_v2_fp_fixed_str_t       fp_priorities, fp_pseudoheaders;
 +    ngx_uint_t                       fp_windowupdate;
 +    ngx_str_t                        fp_str;
  };

--- a/patches/release-1.30.0.patch
+++ b/patches/release-1.30.0.patch
@@ -118,10 +118,10 @@ index efe2290..2891bc6 100644
          ngx_log_debug2(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
                         "http2 setting %ui:%ui", id, value);
  
-+        if (!h2c->fp_fingerprinted && h2c->fp_settings.len + 5 <= NGX_FP_V2_BUFFER_SIZE) {
-+            h2c->fp_settings.data[h2c->fp_settings.len] = (uint8_t)id;
-+            *(uint32_t*)(h2c->fp_settings.data + h2c->fp_settings.len + 1)  = (uint32_t)value;
-+            h2c->fp_settings.len += 5;
++        if (!h2c->fp_fingerprinted && h2c->fp_settings.len < NGX_FP_V2_SETTINGS_MAX) {
++            h2c->fp_settings.ids[h2c->fp_settings.len] = (uint16_t)id;
++            h2c->fp_settings.values[h2c->fp_settings.len] = (uint32_t)value;
++            h2c->fp_settings.len++;
 +        }
 +
          switch (id) {
@@ -141,16 +141,17 @@ diff --git a/src/http/v2/ngx_http_v2.h b/src/http/v2/ngx_http_v2.h
 index 9605c8a..026f3c7 100644
 --- a/src/http/v2/ngx_http_v2.h
 +++ b/src/http/v2/ngx_http_v2.h
-@@ -17,6 +17,8 @@
+@@ -17,6 +17,9 @@
  
  #define NGX_HTTP_V2_STATE_BUFFER_SIZE    16
  
 +#define NGX_FP_V2_BUFFER_SIZE            32
++#define NGX_FP_V2_SETTINGS_MAX           8
 +
  #define NGX_HTTP_V2_DEFAULT_FRAME_SIZE   (1 << 14)
  #define NGX_HTTP_V2_MAX_FRAME_SIZE       ((1 << 24) - 1)
  
-@@ -121,6 +123,12 @@ typedef struct {
+@@ -121,6 +124,18 @@ typedef struct {
  } ngx_http_v2_hpack_t;
  
  
@@ -159,19 +160,24 @@ index 9605c8a..026f3c7 100644
 +  size_t len;
 +} ngx_http_v2_fp_fixed_str_t;
 +
++typedef struct {
++  uint16_t   ids[NGX_FP_V2_SETTINGS_MAX];
++  uint32_t   values[NGX_FP_V2_SETTINGS_MAX];
++  ngx_uint_t len;
++} ngx_http_v2_fp_settings_t;
++
 +
  struct ngx_http_v2_connection_s {
      ngx_connection_t                *connection;
      ngx_http_connection_t           *http_connection;
-@@ -168,6 +176,13 @@ struct ngx_http_v2_connection_s {
+@@ -168,6 +183,12 @@ struct ngx_http_v2_connection_s {
      unsigned                         table_update:1;
      unsigned                         blocked:1;
      unsigned                         goaway:1;
 +
 +    unsigned                         fp_fingerprinted:1;
-+    ngx_http_v2_fp_fixed_str_t       fp_settings,
-+                                     fp_priorities,
-+                                     fp_pseudoheaders;
++    ngx_http_v2_fp_settings_t        fp_settings;
++    ngx_http_v2_fp_fixed_str_t       fp_priorities, fp_pseudoheaders;
 +    ngx_uint_t                       fp_windowupdate;
 +    ngx_str_t                        fp_str;
  };

--- a/src/nginx_ssl_fingerprint.c
+++ b/src/nginx_ssl_fingerprint.c
@@ -785,13 +785,14 @@ int ngx_http2_fingerprint(ngx_connection_t *c, ngx_http_v2_connection_t *h2c)
 {
     unsigned char *pstr = NULL;
     unsigned short n = 0;
-    size_t i;
+    size_t i, j;
+    uint16_t id;
 
     if (h2c->fp_str.len > 0) {
         return NGX_OK;
     }
 
-    n = 4 + h2c->fp_settings.len * 3
+    n = 4 + h2c->fp_settings.len * 17
         + 10 + h2c->fp_priorities.len * 4
         + h2c->fp_pseudoheaders.len * 2;
 
@@ -805,13 +806,19 @@ int ngx_http2_fingerprint(ngx_connection_t *c, ngx_http_v2_connection_t *h2c)
     ngx_log_debug(NGX_LOG_DEBUG_EVENT, c->log, 0, "ngx_http2_fingerprint: alloc bytes: [%d]\n", n);
 
     /* setting */
-    for (i = 0; i < h2c->fp_settings.len; i+=5) {
-        pstr = append_uint8(pstr, h2c->fp_settings.data[i]);
+    for (i = 0, j = 0; i < h2c->fp_settings.len; i++) {
+        id = h2c->fp_settings.ids[i];
+        if (IS_GREASE_CODE(id)) {
+            continue;
+        }
+        if (j++ > 0) {
+            *pstr++ = ';';
+        }
+        pstr = append_uint16(pstr, id);
         *pstr++ = ':';
-        pstr = append_uint32(pstr, *(uint32_t*)(h2c->fp_settings.data+i+1));
-        *pstr++ = ';';
+        pstr = append_uint32(pstr, h2c->fp_settings.values[i]);
     }
-    *(pstr-1) = '|';
+    *pstr++ = '|';
 
     /* windows update */
     pstr = append_uint32(pstr, h2c->fp_windowupdate);


### PR DESCRIPTION
Closes #79.

Closes three defects in HTTP/2 SETTINGS capture (`patches/release-1.29.8.patch`, `release-1.30.0.patch`, `src/nginx_ssl_fingerprint.c`).

`fp_settings` switches from packed `u_char data[32]` (5-byte `[u8 id][u32 value]` entries) to a typed struct-of-arrays. Reader switches to separator-first emission and filters GREASE ids.

1. `uint16_t ids[]` preserves full wire width; reader skips GREASE via `IS_GREASE_CODE()` (same macro `ngx_ssl_ja3` / `ngx_ssl_ja4` use for TLS ciphers/extensions/sigalgs).
2. `uint32_t values[]` is naturally aligned, no more `uint32_t` writes at odd offsets.
3. Separator-first reader, no `*(pstr-1) = '|'` rewrite, safe for `len == 0`.

`NGX_FP_V2_SETTINGS_MAX = 8` covers the max observed in live traffic (7 parameters) plus one Chrome `--http2-grease-settings` GREASE id on top of the standard 4-parameter set. +16 B per H2 connection.

## Compatibility

Output format changes:

- **non-GREASE id ≤ 255** — identical (covers all standard parameters seen today; both u8 and u16 print plain decimal without leading zeros).
- **non-GREASE id > 255** — now distinguishable (previously collapsed by the `(uint8_t)` cast).
- **GREASE ids (`0x?a?a`)** — used to be emitted as their truncated u8 form (10, 26, 42 …); now skipped entirely. Stabilizes the fingerprint for `--http2-grease-settings` clients, matches existing `ngx_ssl_ja3` / `ngx_ssl_ja4` behavior.
