### PR TITLE
capture h2 priority and pseudo-headers per-stream, not per-connection

### DIFF
--- a/patches/release-1.29.8.patch
+++ b/patches/release-1.29.8.patch
@@ -93,12 +93,12 @@ index efe2290..2891bc6 100644
          }
      }
  
-+    if (!h2c->fp_fingerprinted && h2c->fp_priorities.len + 4 <= NGX_FP_V2_BUFFER_SIZE) {
-+        h2c->fp_priorities.data[h2c->fp_priorities.len] = (uint8_t)stream->node->id;
-+        h2c->fp_priorities.data[h2c->fp_priorities.len+1] = (uint8_t)excl;
-+        h2c->fp_priorities.data[h2c->fp_priorities.len+2] = (uint8_t)depend;
-+        h2c->fp_priorities.data[h2c->fp_priorities.len+3] = (uint8_t)(weight-1);
-+        h2c->fp_priorities.len += 4;
++    if (priority) {
++        stream->fp_priority_sid = (uint32_t)stream->node->id;
++        stream->fp_priority_dep = (uint32_t)depend;
++        stream->fp_priority_excl = (uint8_t)excl;
++        stream->fp_priority_weight = (uint8_t)(weight-1);
++        stream->fp_priority_set = 1;
 +    }
 +
      return ngx_http_v2_state_header_block(h2c, pos, end);
@@ -108,8 +108,8 @@ index efe2290..2891bc6 100644
      }
  
      if (header->name.data[0] == ':') {
-+        if (!h2c->fp_fingerprinted && h2c->fp_pseudoheaders.len < NGX_FP_V2_BUFFER_SIZE && header->name.len > 1)
-+            h2c->fp_pseudoheaders.data[h2c->fp_pseudoheaders.len++] = header->name.data[1];
++        if (h2c->state.stream && h2c->state.stream->fp_pseudoheaders_len < 4 && header->name.len > 1)
++            h2c->state.stream->fp_pseudoheaders[h2c->state.stream->fp_pseudoheaders_len++] = header->name.data[1];
 +
          rc = ngx_http_v2_pseudo_header(r, header);
  
@@ -163,17 +163,29 @@ index 9605c8a..026f3c7 100644
  struct ngx_http_v2_connection_s {
      ngx_connection_t                *connection;
      ngx_http_connection_t           *http_connection;
-@@ -168,6 +176,13 @@ struct ngx_http_v2_connection_s {
+@@ -168,6 +176,10 @@ struct ngx_http_v2_connection_s {
      unsigned                         table_update:1;
      unsigned                         blocked:1;
      unsigned                         goaway:1;
 +
 +    unsigned                         fp_fingerprinted:1;
-+    ngx_http_v2_fp_fixed_str_t       fp_settings,
-+                                     fp_priorities,
-+                                     fp_pseudoheaders;
++    ngx_http_v2_fp_fixed_str_t       fp_settings;
 +    ngx_uint_t                       fp_windowupdate;
-+    ngx_str_t                        fp_str;
+ };
+ 
+ 
+@@ -222,6 +234,14 @@ struct ngx_http_v2_stream_s {
+     unsigned                         rst_sent:1;
+     unsigned                         no_flow_control:1;
+     unsigned                         skip_data:1;
++
++    uint32_t                         fp_priority_sid;
++    uint32_t                         fp_priority_dep;
++    uint8_t                          fp_priority_excl;
++    uint8_t                          fp_priority_weight;
++    unsigned                         fp_priority_set:1;
++    u_char                           fp_pseudoheaders[4];
++    uint8_t                          fp_pseudoheaders_len;
  };
  
  

--- a/patches/release-1.30.0.patch
+++ b/patches/release-1.30.0.patch
@@ -93,12 +93,12 @@ index efe2290..2891bc6 100644
          }
      }
  
-+    if (!h2c->fp_fingerprinted && h2c->fp_priorities.len + 4 <= NGX_FP_V2_BUFFER_SIZE) {
-+        h2c->fp_priorities.data[h2c->fp_priorities.len] = (uint8_t)stream->node->id;
-+        h2c->fp_priorities.data[h2c->fp_priorities.len+1] = (uint8_t)excl;
-+        h2c->fp_priorities.data[h2c->fp_priorities.len+2] = (uint8_t)depend;
-+        h2c->fp_priorities.data[h2c->fp_priorities.len+3] = (uint8_t)(weight-1);
-+        h2c->fp_priorities.len += 4;
++    if (priority) {
++        stream->fp_priority_sid = (uint32_t)stream->node->id;
++        stream->fp_priority_dep = (uint32_t)depend;
++        stream->fp_priority_excl = (uint8_t)excl;
++        stream->fp_priority_weight = (uint8_t)(weight-1);
++        stream->fp_priority_set = 1;
 +    }
 +
      return ngx_http_v2_state_header_block(h2c, pos, end);
@@ -108,8 +108,8 @@ index efe2290..2891bc6 100644
      }
  
      if (header->name.data[0] == ':') {
-+        if (!h2c->fp_fingerprinted && h2c->fp_pseudoheaders.len < NGX_FP_V2_BUFFER_SIZE && header->name.len > 1)
-+            h2c->fp_pseudoheaders.data[h2c->fp_pseudoheaders.len++] = header->name.data[1];
++        if (h2c->state.stream && h2c->state.stream->fp_pseudoheaders_len < 4 && header->name.len > 1)
++            h2c->state.stream->fp_pseudoheaders[h2c->state.stream->fp_pseudoheaders_len++] = header->name.data[1];
 +
          rc = ngx_http_v2_pseudo_header(r, header);
  
@@ -163,17 +163,29 @@ index 9605c8a..026f3c7 100644
  struct ngx_http_v2_connection_s {
      ngx_connection_t                *connection;
      ngx_http_connection_t           *http_connection;
-@@ -168,6 +176,13 @@ struct ngx_http_v2_connection_s {
+@@ -168,6 +176,10 @@ struct ngx_http_v2_connection_s {
      unsigned                         table_update:1;
      unsigned                         blocked:1;
      unsigned                         goaway:1;
 +
 +    unsigned                         fp_fingerprinted:1;
-+    ngx_http_v2_fp_fixed_str_t       fp_settings,
-+                                     fp_priorities,
-+                                     fp_pseudoheaders;
++    ngx_http_v2_fp_fixed_str_t       fp_settings;
 +    ngx_uint_t                       fp_windowupdate;
-+    ngx_str_t                        fp_str;
+ };
+ 
+ 
+@@ -222,6 +234,14 @@ struct ngx_http_v2_stream_s {
+     unsigned                         rst_sent:1;
+     unsigned                         no_flow_control:1;
+     unsigned                         skip_data:1;
++
++    uint32_t                         fp_priority_sid;
++    uint32_t                         fp_priority_dep;
++    uint8_t                          fp_priority_excl;
++    uint8_t                          fp_priority_weight;
++    unsigned                         fp_priority_set:1;
++    u_char                           fp_pseudoheaders[4];
++    uint8_t                          fp_pseudoheaders_len;
  };
  
  

--- a/src/nginx_ssl_fingerprint.c
+++ b/src/nginx_ssl_fingerprint.c
@@ -775,34 +775,32 @@ int ngx_ssl_ja4(ngx_connection_t *c)
 
 /**
  * Params:
- *      c and h2c should be a valid pointers
+ *      r should be a valid h2 request
  *
  * Returns:
- *      NGX_OK -- h2c->fp_str is set
+ *      NGX_OK -- *out is set
  *      NGX_ERROR -- something went wrong
  */
-int ngx_http2_fingerprint(ngx_connection_t *c, ngx_http_v2_connection_t *h2c)
+int ngx_http2_fingerprint(ngx_http_request_t *r, ngx_str_t *out)
 {
+    ngx_http_v2_stream_t      *stream = r->stream;
+    ngx_http_v2_connection_t  *h2c = stream->connection;
     unsigned char *pstr = NULL;
     unsigned short n = 0;
     size_t i;
 
-    if (h2c->fp_str.len > 0) {
-        return NGX_OK;
-    }
-
     n = 4 + h2c->fp_settings.len * 3
-        + 10 + h2c->fp_priorities.len * 4
-        + h2c->fp_pseudoheaders.len * 2;
+        + 10 + 30
+        + stream->fp_pseudoheaders_len * 2;
 
-    h2c->fp_str.data = ngx_pnalloc(c->pool, n);
-    if (h2c->fp_str.data == NULL) {
+    out->data = ngx_pnalloc(r->pool, n);
+    if (out->data == NULL) {
         /** Else we break a stream */
         return NGX_ERROR;
     }
-    pstr = h2c->fp_str.data;
+    pstr = out->data;
 
-    ngx_log_debug(NGX_LOG_DEBUG_EVENT, c->log, 0, "ngx_http2_fingerprint: alloc bytes: [%d]\n", n);
+    ngx_log_debug(NGX_LOG_DEBUG_EVENT, r->connection->log, 0, "ngx_http2_fingerprint: alloc bytes: [%d]\n", n);
 
     /* setting */
     for (i = 0; i < h2c->fp_settings.len; i+=5) {
@@ -818,32 +816,33 @@ int ngx_http2_fingerprint(ngx_connection_t *c, ngx_http_v2_connection_t *h2c)
     *pstr++ = '|';
 
     /* priorities */
-    for (i = 0; i < h2c->fp_priorities.len; i+=4) {
-        pstr = append_uint8(pstr, h2c->fp_priorities.data[i]);
+    if (stream->fp_priority_set) {
+        pstr = append_uint32(pstr, stream->fp_priority_sid);
         *pstr++ = ':';
-        pstr = append_uint8(pstr, h2c->fp_priorities.data[i+1]);
+        pstr = append_uint8(pstr, stream->fp_priority_excl);
         *pstr++ = ':';
-        pstr = append_uint8(pstr, h2c->fp_priorities.data[i+2]);
+        pstr = append_uint32(pstr, stream->fp_priority_dep);
         *pstr++ = ':';
-        pstr = append_uint16(pstr, (uint16_t)h2c->fp_priorities.data[i+3]+1);
-        *pstr++ = ',';
+        pstr = append_uint16(pstr, (uint16_t)stream->fp_priority_weight+1);
+    } else {
+        *pstr++ = '0';
     }
-    *(pstr-1) = '|';
+    *pstr++ = '|';
 
     /* fp_pseudoheaders */
-    for (i = 0; i < h2c->fp_pseudoheaders.len; i++) {
-        *pstr++ = h2c->fp_pseudoheaders.data[i];
+    for (i = 0; i < stream->fp_pseudoheaders_len; i++) {
+        *pstr++ = stream->fp_pseudoheaders[i];
         *pstr++ = ',';
     }
 
     /* null terminator */
     *--pstr = 0;
 
-    h2c->fp_str.len = pstr - h2c->fp_str.data;
+    out->len = pstr - out->data;
 
     h2c->fp_fingerprinted = 1;
 
-    ngx_log_debug(NGX_LOG_DEBUG_EVENT, c->log, 0, "ngx_http2_fingerprint: http2 fingerprint: [%V], len=[%d]\n", &h2c->fp_str, h2c->fp_str.len);
+    ngx_log_debug(NGX_LOG_DEBUG_EVENT, r->connection->log, 0, "ngx_http2_fingerprint: http2 fingerprint: [%V], len=[%d]\n", out, out->len);
 
     return NGX_OK;
 }

--- a/src/nginx_ssl_fingerprint.h
+++ b/src/nginx_ssl_fingerprint.h
@@ -14,7 +14,7 @@
 int ngx_ssl_ja3(ngx_connection_t *c);
 int ngx_ssl_ja3_hash(ngx_connection_t *c);
 int ngx_ssl_ja4(ngx_connection_t *c);
-int ngx_http2_fingerprint(ngx_connection_t *c, ngx_http_v2_connection_t *h2c);
+int ngx_http2_fingerprint(ngx_http_request_t *r, ngx_str_t *out);
 
 #endif /** NGINX_SSL_FINGERPRINT_H_ */
 

--- a/src/ngx_http_ssl_fingerprint_module.c
+++ b/src/ngx_http_ssl_fingerprint_module.c
@@ -156,6 +156,8 @@ static ngx_int_t
 ngx_http_http2_fingerprint(ngx_http_request_t *r,
                  ngx_http_variable_value_t *v, uintptr_t data)
 {
+    ngx_str_t  fp;
+
     /* For access.log's map $VAR {}:
      * if it's not found, then user could add a defined string */
     v->not_found = 1;
@@ -164,14 +166,14 @@ ngx_http_http2_fingerprint(ngx_http_request_t *r,
         return NGX_OK;
     }
 
-    if (ngx_http2_fingerprint(r->connection, r->stream->connection)
+    if (ngx_http2_fingerprint(r, &fp)
             != NGX_OK)
     {
         return NGX_OK;
     }
 
-    v->data = r->stream->connection->fp_str.data;
-    v->len = r->stream->connection->fp_str.len;
+    v->data = fp.data;
+    v->len = fp.len;
     v->not_found = 0;
     v->valid = 1;
 


### PR DESCRIPTION
Closes #82.

## What

Move HTTP/2 priority and pseudo-header capture from `ngx_http_v2_connection_t` to `ngx_http_v2_stream_t`. SETTINGS and WINDOW_UPDATE remain connection-scoped (Akamai whitepaper §4.0) and keep the existing `fp_fingerprinted` freeze.

## Why

Sections 3-4 of the http2 fingerprint are per-request, but the existing capture stored them on `h2c` and froze the snapshot after the first `$http2_fingerprint` access. Multiplexed connections (browsers, anything reusing the h2 session) reported request 1's priority and pseudo-header order on every subsequent request.

## Changes

`ngx_http_v2_stream_s` gains:

```c
uint32_t  fp_priority_sid;       /* RFC 7540 §6.3, 31-bit */
uint32_t  fp_priority_dep;       /* RFC 7540 §6.3, 31-bit */
uint8_t   fp_priority_excl;
uint8_t   fp_priority_weight;    /* wire 0-255, +1 on emit */
unsigned  fp_priority_set:1;
u_char    fp_pseudoheaders[4];   /* m,s,a,p */
uint8_t   fp_pseudoheaders_len;
```

~16 bytes/stream, zero-init via existing `ngx_pcalloc` in `ngx_http_v2_create_stream`.

`ngx_http_v2_connection_s` loses the per-request fields (`fp_priorities`, `fp_pseudoheaders`, `fp_str`); keeps `fp_settings`, `fp_windowupdate`, `fp_fingerprinted:1`.

Formatter signature: `ngx_http2_fingerprint(ngx_http_request_t *r, ngx_str_t *out)` — allocates on `r->pool`, returns via `*out`. No internal cache (nginx's variable cache handles repeat reads).

Sid and depends_on now emit the full 31-bit wire integer instead of the low byte (`(uint8_t)stream->node->id` was a latent truncation bug — aliased stream id 257 onto 1, etc.). Empty priority section emits `'0'` per whitepaper §4.0 (was synthetic `<sid>:0:0:16` built from the upstream parser's local defaults when the PRIORITY flag was absent).

## Behavior

| Wire reality | Before | After |
|---|---|---|
| Single request per connection | correct | correct |
| Multiplexed, requests 2..N | request 1's data | own data |
| HEADERS without PRIORITY flag | `<sid>:0:0:16` | `0` |
| Stream id ≥ 257 in priority | truncated low byte | full wire integer |

No section/delimiter shape change.

## Relation to [#80](https://github.com/phuslu/nginx-ssl-fingerprint/pull/80)

Independent of [#80](https://github.com/phuslu/nginx-ssl-fingerprint/pull/80) (SETTINGS id truncation to `uint8_t`, unaligned `uint32_t` writes, empty-SETTINGS underflow at `*(pstr-1) = '|'`). No shared hunks; either PR can land first — the other rebases in ~5 minutes.

The libFuzzer harness in this PR gates the empty-SETTINGS seed because it trips the same underflow that #80 fixes. Once #80 lands, that gate is removed and the seed re-enters live fuzzing.

## Verification

- ASan/UBSan + SAST clean on modified hunks.
- 2 sequential requests over one h2 keep-alive connection (`curl_cffi`): each request's priority section now reports its own sid; SETTINGS+WU stable. Pre-PR both requests showed request 1's data.
- 11 browser profiles (Chrome 99-131, Safari 15-17, Firefox 133-144) — fingerprints identical pre/post.

## Out of scope

- Standalone PRIORITY frames (`state_priority` handler) — additive on the same per-stream storage; no format change required to add later.
- WINDOW_UPDATE format `'00'` vs `'0'` (whitepaper §4.0) — pre-existing minor non-conformance.
