### PR TITLE
ja4: keep wire order of sigalgs

### DIFF
--- a/src/nginx_ssl_fingerprint.c
+++ b/src/nginx_ssl_fingerprint.c
@@ -668,14 +668,6 @@ int ngx_ssl_ja4(ngx_connection_t *c)
                 }
             }
 
-            for (i = 1; i < sigalg_count; i++) {
-                n = hash_buf[i];
-                for (j = i; j > 0 && hash_buf[j - 1] > n; j--) {
-                    hash_buf[j] = hash_buf[j - 1];
-                }
-                hash_buf[j] = n;
-            }
-
             for (i = 0; i < sigalg_count; i++) {
                 hash_part[0] = hex[(hash_buf[i] >> 12) & 0xf];
                 hash_part[1] = hex[(hash_buf[i] >> 8) & 0xf];


### PR DESCRIPTION
Re-opens & fixes [#76](https://github.com/phuslu/nginx-ssl-fingerprint/issues/76) point 5 — sigalgs ordering. Regression of [`5aea07c`](https://github.com/phuslu/nginx-ssl-fingerprint/commit/5aea07c), introduced by [`d80e664`](https://github.com/phuslu/nginx-ssl-fingerprint/commit/d80e664) (consolidated `exts[]` and `sigalgs[]` into a shared `hash_buf[]`, inadvertently re-added the insertion sort). Removes the sort between the sigalg fill loop and the SHA-256 hex-dump in `ngx_ssl_ja4()`.

Spec rationale and SHA-256 evidence are in [issue #76 point 5](https://github.com/phuslu/nginx-ssl-fingerprint/issues/76).

For the macOS curl 8.7.1 ClientHello (sorted-exts `000a,000b,000d,002b,0033`; wire-order sigalgs `0806,0601,0603,0805,0501,0503,0804,0401,0403,0201,0203`):

| sigalgs ordering in SHA-256 input | sha256[:12] |
|---|---|
| wire (per spec) | `7395dae3b2f3` |
| sorted (the bug) | `8ffbba045b07` |

Post-fix nginx emits `7395dae3b2f3` — matches the spec-defined value.
